### PR TITLE
Feature/CT 6736 Easy File Pusher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ artifacts/
 *.userprefs
 *DS_Store
 *.sln.ide
+launchSettings.json

--- a/README.md
+++ b/README.md
@@ -1,8 +1,53 @@
-# easy-file-pusher
+# Easy File Pusher
 
-The Coveo Easy File Pusher is a command-line tool to push documents stored in the local file system to a Coveo Push source. The source must have been created first using the Coveo Administration Console. Then running the tool scans the specified local folder and pushes the files matching the specified filter. Launching the tool without any arguments displays the usage i.e. the arguments that can be specified on the command line.
+The Coveo Easy File Pusher is a command-line tool to push documents stored in the local file system to a Coveo Push source. The source must have been created first using the Coveo Administration Console. Then running the tool scans the specified local folder and pushes the files matching the specified filter.
 
-Since the tool was developed using .NET Core, it can be executed on the operating systems supported by .NET Core: Windows, Mac and Linux. An executable for each supported operating system is available for download.
+## How to use it
+
+Launching the tool without any arguments displays the usage i.e. the arguments that can be specified on the command line:
+```
+ERROR(S):
+  Required option 'e, environment' is missing.
+  Required option 'r, region' is missing.
+  Required option 'o, organizationid' is missing.
+  Required option 's, sourceid' is missing.
+  Required option 'k, apikey' is missing.
+  Required option 'f, folder' is missing.
+
+  -e, --environment       Required. Cloud environment: Hipaa, Prod, QA or Dev.
+
+  -r, --region            Required. Cloud region: UsEast1 or EuWest1.
+
+  -o, --organizationid    Required. ID of the organization in which to push documents.
+
+  -s, --sourceid          Required. ID of the source in which to push documents.
+
+  -k, --apikey            Required. API key to use.
+
+  -f, --folder            Required. Path of the local folder that contains the documents to index.
+
+  --include               (Default: *) Wildcard expression for which matching files will be pushed. All files are pushed
+                          by default.
+
+  --recursive             (Default: true) Whether to recursively search in sub-folders for files to push. Sub-folders
+                          are searched by default.
+
+  --batchsize             (Default: 10) How many files to push per batch.
+
+  --help                  Display this help screen.
+
+  --version               Display version information.
+```
+Note that for the most used arguments, each can be specified using either a long or a short name.
+
+Here is an example of what the command-line should look like when specifying all the required arguments:
+```
+Coveo.Connectors.EasyFilePusher -e Prod -r UsEast1 -o OrgNameHerez1x2c3v4 -s OrgNameHerez1x2c3v4-q1w2e3r4t5y6u7i8o9p0zxcvbn --apikey xxaaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee -f "C:\Folder\Path\Here"
+```
+
+## Supported Operating Systems
+
+Since the tool was developed using .NET Core, it can be executed on the operating systems supported by .NET Core, so Windows, Mac and Linux. An executable for each supported operating system is available for download.
 
 Regarding the executable for Linux, after downloading it to a Linux machine, the "is executable" flag must be set on the file before running it. This is necessary for the executable to work.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # easy-file-pusher
-An easy way to push documents stored in a file system to a Coveo Push source using dotnet core.
 
-![.NET Core](https://github.com/coveooss/easy-file-pusher/workflows/.NET%20Core/badge.svg?branch=master)
+The Coveo Easy File Pusher is a command-line tool to push documents stored in the local file system to a Coveo Push source. The source must have been created first using the Coveo Administration Console. Then the tool scans the specified local folder and pushes the files matching the specified filter. Launching the tool without any arguments displays the usage i.e. the arguments that can be specified on the command line.
 
-# WIP
+Since the tool was developed using .NET Core, it can be executed on the operating systems supported by .NET Core: Windows, Mac and Linux. An executable for each supported operating system is available for download.
+
+Regarding the executable for Linux, after downloading it to a Linux machine, the "is executable" flag must be set on the file before running it. This is necessary for the executable to work.
+
+Regarding the executable for Mac, note that the executable has not been signed with a certificate. Trying to run it on a Mac will cause a security warning to be displayed. Running it on a Mac is possible, but requires additional steps. Refer to the following page for more details:
+https://support.apple.com/en-ca/guide/mac-help/mh40616/mac

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # easy-file-pusher
 
-The Coveo Easy File Pusher is a command-line tool to push documents stored in the local file system to a Coveo Push source. The source must have been created first using the Coveo Administration Console. Then the tool scans the specified local folder and pushes the files matching the specified filter. Launching the tool without any arguments displays the usage i.e. the arguments that can be specified on the command line.
+The Coveo Easy File Pusher is a command-line tool to push documents stored in the local file system to a Coveo Push source. The source must have been created first using the Coveo Administration Console. Then running the tool scans the specified local folder and pushes the files matching the specified filter. Launching the tool without any arguments displays the usage i.e. the arguments that can be specified on the command line.
 
 Since the tool was developed using .NET Core, it can be executed on the operating systems supported by .NET Core: Windows, Mac and Linux. An executable for each supported operating system is available for download.
 

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ ERROR(S):
 ```
 Note that for the most used arguments, each can be specified using either a long or a short name.
 
-Here is an example of what the command-line should look like when specifying all the required arguments:
+Here is an example of what the command line should look like when specifying all the required arguments:
 ```
 Coveo.Connectors.EasyFilePusher -e Prod -r UsEast1 -o OrgNameHerez1x2c3v4 -s OrgNameHerez1x2c3v4-q1w2e3r4t5y6u7i8o9p0zxcvbn --apikey xxaaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee -f "C:\Folder\Path\Here"
 ```
 
 ## Supported Operating Systems
 
-Since the tool was developed using .NET Core, it can be executed on the operating systems supported by .NET Core, so Windows, Mac and Linux. An executable for each supported operating system is available for download.
+Since the tool was developed using .NET Core, it can be executed on the operating systems supported by .NET Core so Windows, Mac and Linux. An executable for each supported operating system is available for download.
 
 Regarding the executable for Linux, after downloading it to a Linux machine, the "is executable" flag must be set on the file before running it. This is necessary for the executable to work.
 

--- a/src/Coveo.Connectors.EasyFilePusher/Coveo.Connectors.EasyFilePusher.csproj
+++ b/src/Coveo.Connectors.EasyFilePusher/Coveo.Connectors.EasyFilePusher.csproj
@@ -6,12 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Remove="C:\Users\rquirion\.nuget\packages\coveo.connectors.utilities.platformsdk\1.1.0\contentFiles\any\netstandard2.0\log4net.Ext.Json.LICENSE.txt" />
+    <Content Remove="C:\Users\rquirion\.nuget\packages\coveo.connectors.utilities.platformsdk\1.1.0\contentFiles\any\netstandard2.0\log4net.Ext.Json.README.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Coveo.Connectors.Utilities.PlatformSdk" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Other Files\" />
     <Folder Include="Resources\" />
   </ItemGroup>
 

--- a/src/Coveo.Connectors.EasyFilePusher/Coveo.Connectors.EasyFilePusher.csproj
+++ b/src/Coveo.Connectors.EasyFilePusher/Coveo.Connectors.EasyFilePusher.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Coveo.Connectors.Utilities.PlatformSdk" Version="1.0.0" />
+    <PackageReference Include="Coveo.Connectors.Utilities.PlatformSdk" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Coveo.Connectors.EasyFilePusher/Coveo.Connectors.EasyFilePusher.csproj
+++ b/src/Coveo.Connectors.EasyFilePusher/Coveo.Connectors.EasyFilePusher.csproj
@@ -6,22 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Remove="C:\Users\rquirion\.nuget\packages\coveo.connectors.utilities.platformsdk\1.1.0\contentFiles\any\netstandard2.0\log4net.Ext.Json.LICENSE.txt" />
-    <Content Remove="C:\Users\rquirion\.nuget\packages\coveo.connectors.utilities.platformsdk\1.1.0\contentFiles\any\netstandard2.0\log4net.Ext.Json.README.txt" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Coveo.Connectors.Utilities.PlatformSdk" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Resources\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Update="C:\Users\rquirion\.nuget\packages\coveo.connectors.utilities.platformsdk\1.0.0\contentFiles\any\netstandard2.0\log4net.Ext.Json.LICENSE.txt" Link="Other Files\log4net.Ext.Json.LICENSE.txt" />
-    <Content Update="C:\Users\rquirion\.nuget\packages\coveo.connectors.utilities.platformsdk\1.0.0\contentFiles\any\netstandard2.0\log4net.Ext.Json.README.txt" Link="Other Files\log4net.Ext.Json.README.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Coveo.Connectors.EasyFilePusher/Coveo.Connectors.EasyFilePusher.csproj
+++ b/src/Coveo.Connectors.EasyFilePusher/Coveo.Connectors.EasyFilePusher.csproj
@@ -7,6 +7,21 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Coveo.Connectors.Utilities.PlatformSdk" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Other Files\" />
+    <Folder Include="Resources\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="C:\Users\rquirion\.nuget\packages\coveo.connectors.utilities.platformsdk\1.0.0\contentFiles\any\netstandard2.0\log4net.Ext.Json.LICENSE.txt" Link="Other Files\log4net.Ext.Json.LICENSE.txt" />
+    <Content Update="C:\Users\rquirion\.nuget\packages\coveo.connectors.utilities.platformsdk\1.0.0\contentFiles\any\netstandard2.0\log4net.Ext.Json.README.txt" Link="Other Files\log4net.Ext.Json.README.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="..\..\icon.png" Link="Resources\icon.png" />
   </ItemGroup>
 
 </Project>

--- a/src/Coveo.Connectors.EasyFilePusher/Program.cs
+++ b/src/Coveo.Connectors.EasyFilePusher/Program.cs
@@ -23,7 +23,7 @@ namespace Coveo.Connectors.EasyFilePusher
         /// <summary>
         /// Entry point of the program.
         /// </summary>
-        /// <param name="p_Args"></param>
+        /// <param name="p_Args">Command-line arguments.</param>
         private static void Main(string[] p_Args)
         {
             new Parser(settings => {

--- a/src/Coveo.Connectors.EasyFilePusher/Program.cs
+++ b/src/Coveo.Connectors.EasyFilePusher/Program.cs
@@ -1,15 +1,160 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using CommandLine;
+using Coveo.Connectors.Utilities.PlatformSdk;
+using Coveo.Connectors.Utilities.PlatformSdk.Config;
+using Coveo.Connectors.Utilities.PlatformSdk.Helpers;
+using Coveo.Connectors.Utilities.PlatformSdk.Model.Document;
 
 namespace Coveo.Connectors.EasyFilePusher
 {
     /// <summary>
-    /// Entry point.
+    /// Main class of the program.
     /// </summary>
     public class Program
     {
-        private static void Main(string[] args)
+        private const string INVALID_CLOUD_REGION = "Invalid cloud region.";
+        private const string INVALID_CLOUD_ENVIRONMENT = "Invalid cloud environment.";
+        private const string HIPAA_INVALID_FOR_EUWEST1 = "The " + nameof(CloudEnvironment.Hipaa) + " environment is not available for the region " + nameof(CloudRegion.EuWest1) + ".";
+
+        /// <summary>
+        /// Entry point of the program.
+        /// </summary>
+        /// <param name="p_Args"></param>
+        private static void Main(string[] p_Args)
         {
-            Console.WriteLine("Hello World!");
+            new Parser(settings => {
+                settings.CaseInsensitiveEnumValues = true;
+                settings.HelpWriter = Console.Out;
+            }).ParseArguments<ProgramArguments>(p_Args).WithParsed(parsedArgs => {
+                IndexFiles(parsedArgs);
+            });
+        }
+
+        /// <summary>
+        /// Indexes the files located in the specified folder.
+        /// </summary>
+        /// <param name="p_Args">Parsed command-line arguments.</param>
+        private static void IndexFiles(ProgramArguments p_Args)
+        {
+            ICoveoPlatformConfig platformConfig = new CoveoPlatformConfig(GetPushApiUrl(p_Args),  GetPlatformApiUrl(p_Args), p_Args.ApiKey, p_Args.Organization);
+            using (ICoveoPlatformClient platformClient = new CoveoPlatformClient(platformConfig)) {
+                IList<PushDocument> documentBatch = new List<PushDocument>();
+                foreach (FileInfo fileInfo in new DirectoryInfo(p_Args.Folder).EnumerateFiles(p_Args.Include, p_Args.Recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)) {
+                    PushDocument document = new PushDocument(new Uri(fileInfo.FullName).AbsoluteUri) {
+                        ModifiedDate = fileInfo.LastWriteTimeUtc
+                    };
+                    PushDocumentHelper.SetContentFromFile(document, fileInfo.FullName);
+                    documentBatch.Add(document);
+
+                    if (documentBatch.Count >= p_Args.BatchSize) {
+                        // Push this batch of documents.
+                        SendBatch(platformClient, documentBatch, p_Args.SourceId);
+                    }
+                }
+
+                // Send the (partial) final batch of documents.
+                SendBatch(platformClient, documentBatch, p_Args.SourceId);
+            }
+        }
+
+        /// <summary>
+        /// Sends a batch of documents to the platform.
+        /// </summary>
+        /// <param name="p_PlatformClient">The instance of <see cref="ICoveoPlatformClient"/> to use.</param>
+        /// <param name="p_DocumentBatch">The batch of documents to send.</param>
+        /// <param name="p_SourceId">ID of the source in which to push documents.</param>
+        private static void SendBatch(ICoveoPlatformClient p_PlatformClient,
+                                      IList<PushDocument> p_DocumentBatch,
+                                      string p_SourceId)
+        {
+            if (p_DocumentBatch.Count == 0) {
+                return;
+            }
+
+            p_PlatformClient.DocumentManager.AddOrUpdateDocuments(p_SourceId, p_DocumentBatch, null);
+
+            p_DocumentBatch.Clear();
+        }
+
+        /// <summary>
+        /// Gets the push API endpoint URL to use that matches the command-line arguments specified.
+        /// </summary>
+        /// <param name="p_Args">Parsed command-line arguments.</param>
+        /// <returns>The push API endpoint URL to use.</returns>
+        private static string GetPushApiUrl(ProgramArguments p_Args)
+        {
+            switch (p_Args.Region) {
+                case CloudRegion.UsEast1:
+                    switch (p_Args.Environment) {
+                        case CloudEnvironment.Hipaa:
+                            return Constants.Endpoint.UsEast1.HIPAA_PUSH_API_URL;
+                        case CloudEnvironment.Prod:
+                            return Constants.Endpoint.UsEast1.PROD_PUSH_API_URL;
+                        case CloudEnvironment.QA:
+                            return Constants.Endpoint.UsEast1.QA_PUSH_API_URL;
+                        case CloudEnvironment.Dev:
+                            return Constants.Endpoint.UsEast1.DEV_PUSH_API_URL;
+                        default:
+                            throw new InvalidEnumArgumentException(INVALID_CLOUD_ENVIRONMENT);
+                    }
+                case CloudRegion.EuWest1:
+                    switch (p_Args.Environment) {
+                        case CloudEnvironment.Hipaa:
+                            throw new InvalidEnumArgumentException(HIPAA_INVALID_FOR_EUWEST1);
+                        case CloudEnvironment.Prod:
+                            return Constants.Endpoint.EuWest1.PROD_PUSH_API_URL;
+                        case CloudEnvironment.QA:
+                            return Constants.Endpoint.EuWest1.QA_PUSH_API_URL;
+                        case CloudEnvironment.Dev:
+                            return Constants.Endpoint.EuWest1.DEV_PUSH_API_URL;
+                        default:
+                            throw new InvalidEnumArgumentException(INVALID_CLOUD_ENVIRONMENT);
+                    }
+                default:
+                    throw new InvalidEnumArgumentException(INVALID_CLOUD_REGION);
+            }
+        }
+
+        /// <summary>
+        /// Gets the platform endpoint URL to use that matches the command-line arguments specified.
+        /// </summary>
+        /// <param name="p_Args">Parsed command-line arguments.</param>
+        /// <returns>The platform endpoint URL to use.</returns>
+        private static string GetPlatformApiUrl(ProgramArguments p_Args)
+        {
+            switch (p_Args.Region) {
+                case CloudRegion.UsEast1:
+                    switch (p_Args.Environment) {
+                        case CloudEnvironment.Hipaa:
+                            return Constants.PlatformEndpoint.UsEast1.HIPAA_PLATFORM_API_URL;
+                        case CloudEnvironment.Prod:
+                            return Constants.PlatformEndpoint.UsEast1.PROD_PLATFORM_API_URL;
+                        case CloudEnvironment.QA:
+                            return Constants.PlatformEndpoint.UsEast1.QA_PLATFORM_API_URL;
+                        case CloudEnvironment.Dev:
+                            return Constants.PlatformEndpoint.UsEast1.DEV_PLATFORM_API_URL;
+                        default:
+                            throw new InvalidEnumArgumentException(INVALID_CLOUD_ENVIRONMENT);
+                    }
+                case CloudRegion.EuWest1:
+                    switch (p_Args.Environment) {
+                        case CloudEnvironment.Hipaa:
+                            throw new InvalidEnumArgumentException(HIPAA_INVALID_FOR_EUWEST1);
+                        case CloudEnvironment.Prod:
+                            return Constants.PlatformEndpoint.EuWest1.PROD_PLATFORM_API_URL;
+                        case CloudEnvironment.QA:
+                            return Constants.PlatformEndpoint.EuWest1.QA_PLATFORM_API_URL;
+                        case CloudEnvironment.Dev:
+                            return Constants.PlatformEndpoint.EuWest1.DEV_PLATFORM_API_URL;
+                        default:
+                            throw new InvalidEnumArgumentException(INVALID_CLOUD_ENVIRONMENT);
+                    }
+                default:
+                    throw new InvalidEnumArgumentException(INVALID_CLOUD_REGION);
+            }
         }
     }
 }

--- a/src/Coveo.Connectors.EasyFilePusher/Program.cs
+++ b/src/Coveo.Connectors.EasyFilePusher/Program.cs
@@ -60,7 +60,7 @@ namespace Coveo.Connectors.EasyFilePusher
                     PushDocument document = new PushDocument(new Uri(fileInfo.FullName).AbsoluteUri) {
                         ModifiedDate = fileInfo.LastWriteTimeUtc
                     };
-                    PushDocumentHelper.SetContentFromFile(document, fileInfo.FullName);
+                    PushDocumentHelper.SetBinaryContentFromFileAndCompress(document, fileInfo.FullName);
                     documentBatch.Add(document);
 
                     if (documentBatch.Count >= p_Args.BatchSize) {

--- a/src/Coveo.Connectors.EasyFilePusher/ProgramArguments.cs
+++ b/src/Coveo.Connectors.EasyFilePusher/ProgramArguments.cs
@@ -34,7 +34,8 @@ namespace Coveo.Connectors.EasyFilePusher
 
         [Option('f', nameof(folder),
             Required = true,
-            HelpText = "Path of the local folder that contains the documents to index.")] public string folder { get; set; } = "";
+            HelpText = "Path of the local folder that contains the documents to index.")]
+        public string folder { get; set; } = "";
 
         [Option(
             Default = "*",

--- a/src/Coveo.Connectors.EasyFilePusher/ProgramArguments.cs
+++ b/src/Coveo.Connectors.EasyFilePusher/ProgramArguments.cs
@@ -1,0 +1,106 @@
+﻿using CommandLine;
+
+namespace Coveo.Connectors.EasyFilePusher
+{
+    /// <summary>
+    /// Definition of the program input arguments.
+    /// </summary>
+    public class ProgramArguments
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        [Option(Required = true, HelpText = "Cloud environment: " + nameof(CloudEnvironment.Hipaa) + ", " + nameof(CloudEnvironment.Prod) + ", " + nameof(CloudEnvironment.QA) + " or " + nameof(CloudEnvironment.Dev) + ".")]
+        public CloudEnvironment Environment { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Option(Required = true, HelpText = "Cloud region: " + nameof(CloudRegion.UsEast1) + " or " + nameof(CloudRegion.EuWest1) + ".")]
+        public CloudRegion Region { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Option(Required = true, HelpText = "ID of the organization in which to push documents.")]
+        public string Organization { get; set; } = "";
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Option(Required = true, HelpText = "ID of the source in which to push documents.")]
+        public string SourceId { get; set; } = "";
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Option(Required = true, HelpText = "API key to use.")]
+        public string ApiKey { get; set; } = "";
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Option(Required = true, HelpText = "Path of the local folder that contains the documents to index.")]
+        public string Folder { get; set; } = "";
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Option(Default = "*", HelpText = "Wildcard expression for which matching files will be pushed. All files are pushed by default")]
+        public string Include { get; set; } = "";
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Option(Default = true, HelpText = "Whether to recursively search in sub-folders for files to push. Sub-folders are searched by default.")]
+        public bool Recursive { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Option(Default = 10, HelpText = "How many files to push per batch.")]
+        public int BatchSize { get; set; }
+    }
+
+    /// <summary>
+    /// Cloud environments in which documents can be pushed.
+    /// </summary>
+    public enum CloudEnvironment
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        Hipaa,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        Prod,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        QA,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        Dev
+    }
+
+    /// <summary>
+    /// Cloud regions in which documents can be pushed.
+    /// </summary>
+    public enum CloudRegion
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        UsEast1,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        EuWest1
+    }
+}

--- a/src/Coveo.Connectors.EasyFilePusher/ProgramArguments.cs
+++ b/src/Coveo.Connectors.EasyFilePusher/ProgramArguments.cs
@@ -5,102 +5,70 @@ namespace Coveo.Connectors.EasyFilePusher
     /// <summary>
     /// Definition of the program input arguments.
     /// </summary>
-    public class ProgramArguments
+    internal class ProgramArguments
     {
-        /// <summary>
-        /// 
-        /// </summary>
-        [Option(Required = true, HelpText = "Cloud environment: " + nameof(CloudEnvironment.Hipaa) + ", " + nameof(CloudEnvironment.Prod) + ", " + nameof(CloudEnvironment.QA) + " or " + nameof(CloudEnvironment.Dev) + ".")]
-        public CloudEnvironment Environment { get; set; }
+        [Option('e', nameof(environment),
+            Required = true,
+            HelpText = "Cloud environment: " + nameof(CloudEnvironment.Hipaa) + ", " + nameof(CloudEnvironment.Prod) + ", " + nameof(CloudEnvironment.QA) + " or " + nameof(CloudEnvironment.Dev) + ".")]
+        public CloudEnvironment environment { get; set; }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        [Option(Required = true, HelpText = "Cloud region: " + nameof(CloudRegion.UsEast1) + " or " + nameof(CloudRegion.EuWest1) + ".")]
-        public CloudRegion Region { get; set; }
+        [Option('r', nameof(region),
+            Required = true,
+            HelpText = "Cloud region: " + nameof(CloudRegion.UsEast1) + " or " + nameof(CloudRegion.EuWest1) + ".")]
+        public CloudRegion region { get; set; }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        [Option(Required = true, HelpText = "ID of the organization in which to push documents.")]
-        public string Organization { get; set; } = "";
+        [Option('o', nameof(organizationid),
+            Required = true,
+            HelpText = "ID of the organization in which to push documents.")]
+        public string organizationid { get; set; } = "";
 
-        /// <summary>
-        /// 
-        /// </summary>
-        [Option(Required = true, HelpText = "ID of the source in which to push documents.")]
-        public string SourceId { get; set; } = "";
+        [Option('s', nameof(sourceid),
+            Required = true,
+            HelpText = "ID of the source in which to push documents.")]
+        public string sourceid { get; set; } = "";
 
-        /// <summary>
-        /// 
-        /// </summary>
-        [Option(Required = true, HelpText = "API key to use.")]
-        public string ApiKey { get; set; } = "";
+        [Option('k', nameof(apikey),
+            Required = true,
+            HelpText = "API key to use.")]
+        public string apikey { get; set; } = "";
 
-        /// <summary>
-        /// 
-        /// </summary>
-        [Option(Required = true, HelpText = "Path of the local folder that contains the documents to index.")]
-        public string Folder { get; set; } = "";
+        [Option('f', nameof(folder),
+            Required = true,
+            HelpText = "Path of the local folder that contains the documents to index.")] public string folder { get; set; } = "";
 
-        /// <summary>
-        /// 
-        /// </summary>
-        [Option(Default = "*", HelpText = "Wildcard expression for which matching files will be pushed. All files are pushed by default.")]
+        [Option(
+            Default = "*",
+            HelpText = "Wildcard expression for which matching files will be pushed. All files are pushed by default.")]
         public string Include { get; set; } = "";
 
-        /// <summary>
-        /// 
-        /// </summary>
-        [Option(Default = true, HelpText = "Whether to recursively search in sub-folders for files to push. Sub-folders are searched by default.")]
+        [Option(
+            Default = true,
+            HelpText = "Whether to recursively search in sub-folders for files to push. Sub-folders are searched by default.")]
         public bool Recursive { get; set; }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        [Option(Default = 10, HelpText = "How many files to push per batch.")]
+        [Option(
+            Default = 10,
+            HelpText = "How many files to push per batch.")]
         public int BatchSize { get; set; }
     }
 
     /// <summary>
     /// Cloud environments in which documents can be pushed.
     /// </summary>
-    public enum CloudEnvironment
+    internal enum CloudEnvironment
     {
-        /// <summary>
-        /// 
-        /// </summary>
         Hipaa,
-
-        /// <summary>
-        /// 
-        /// </summary>
         Prod,
-
-        /// <summary>
-        /// 
-        /// </summary>
         QA,
-
-        /// <summary>
-        /// 
-        /// </summary>
         Dev
     }
 
     /// <summary>
     /// Cloud regions in which documents can be pushed.
     /// </summary>
-    public enum CloudRegion
+    internal enum CloudRegion
     {
-        /// <summary>
-        /// 
-        /// </summary>
         UsEast1,
-
-        /// <summary>
-        /// 
-        /// </summary>
         EuWest1
     }
 }

--- a/src/Coveo.Connectors.EasyFilePusher/ProgramArguments.cs
+++ b/src/Coveo.Connectors.EasyFilePusher/ProgramArguments.cs
@@ -46,7 +46,7 @@ namespace Coveo.Connectors.EasyFilePusher
         /// <summary>
         /// 
         /// </summary>
-        [Option(Default = "*", HelpText = "Wildcard expression for which matching files will be pushed. All files are pushed by default")]
+        [Option(Default = "*", HelpText = "Wildcard expression for which matching files will be pushed. All files are pushed by default.")]
         public string Include { get; set; } = "";
 
         /// <summary>


### PR DESCRIPTION
Ce matin, j'ai updaté la référence au PlatformSdk.  J'ai suivi ta recommandation de changer l'appel à PushDocumentHelper par la méthode qui gère du binaire compressé.  J'ai testé, et c'est concluant.

Dans le Content Browser, je peux maintenant chercher des keywords présents dans le contenu des fichiers, et les documents sortent dans les résultats!

J'ai aussi retesté l'effacement de fichiers via le OrderingId, et ça fonctionne aussi.

Bref, tout me semble correct.