### PR TITLE
Feature/ct 6737 publish

### DIFF
--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -39,12 +39,8 @@ jobs:
         exclusions: '*.pdb'
         type: zip
 
-    - name: Ppppp
-      run: "find -iname '*.zip'"
-
     - name: Create pre-release
       uses: marvinpinto/action-automatic-releases@latest
-      if: ${{false}}
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -27,21 +27,17 @@ jobs:
       working-directory: ./src
       run: dotnet test --no-restore --verbosity normal
 
-    - name: Publish WinX86
+    - name: Compile WinX86
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=WinX86 --configuration Release
 
-    - name: Publish MacOsx64
+    - name: Compile MacOsx64
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=MacOsx64 --configuration Release
 
-    - name: Publish LinuxX64
+    - name: Compile LinuxX64
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=LinuxX64 --configuration Release
-
-    - name: TEST SIGN PPPPP 0
-      working-directory: .
-      run: 'CMD /r DIR "C:\Program Files (x86)\signtool.exe" /s /b'
 
     - name: TEST SIGN PPPPP 1
       id: write_file
@@ -52,7 +48,7 @@ jobs:
 
     - name: TEST SIGN PPPPP 2
       working-directory: .
-      run: '"C:\Program Files (x86)\Windows Kits\10\bin\x86\signtool.exe" sign /f win-cert.pfx /p ${{ secrets.WINDOWS_CERT_PWD }} bin\Release\netcoreapp3.1\publish\WinX86\Coveo.Connectors.EasyFilePusher.exe'
+      run: 'CMD /r "C:\Program Files (x86)\Windows Kits\10\bin\x86\signtool.exe" sign /f win-cert.pfx /p ${{ secrets.WINDOWS_CERT_PWD }} bin\Release\netcoreapp3.1\publish\WinX86\Coveo.Connectors.EasyFilePusher.exe'
 
     - name: TEST SIGN PPPPP 3
       working-directory: .

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -2,9 +2,6 @@ name: Publish Test
 
 on: 
   workflow_dispatch:
-    inputs:
-      test:
-        description: 'Input test'  
 
 jobs:
   build-and-prerelease:
@@ -41,7 +38,6 @@ jobs:
         directory: './bin/Release/netcoreapp3.1/publish/WinX86'
         exclusions: '*.pdb'
         type: zip
-          echo "done!"
 
     - name: Create pre-release
       uses: marvinpinto/action-automatic-releases@latest

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -33,6 +33,7 @@ jobs:
       uses: thedoctor0/zip-release@master
       with:
         filename: 'EasyFilePusher_WinX86.zip'
+        path: './bin/Release/netcoreapp3.1/publish'
         directory: './bin/Release/netcoreapp3.1/publish/WinX86'
         exclusions: '*.pdb'
         type: zip

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -32,8 +32,7 @@ jobs:
     - name: Zip WinX86 EXE
       uses: thedoctor0/zip-release@master
       with:
-        filename: 'EasyFilePusher_WinX86.zip'
-        path: './bin/Release/netcoreapp3.1/publish'
+        filename: './bin/Release/netcoreapp3.1/publish/EasyFilePusher_WinX86.zip'
         directory: './bin/Release/netcoreapp3.1/publish/WinX86'
         exclusions: '*.pdb'
         type: zip

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-and-release:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
 
     - uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
         exclusions: '*.pdb'
         type: zip
 
-    - name: Create pre-release
+    - name: Release executables
       uses: marvinpinto/action-automatic-releases@latest
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -22,6 +22,21 @@ jobs:
     - name: Build
       working-directory: ./src
       run: dotnet build --configuration Release --no-restore
+      
+    - name: Prepare certificate 1/2
+      id: write_file
+      uses: timheuer/base64-to-file@v1
+      with:
+        fileName: 'cert.pem'
+        encodedString: ${{ secrets.WINDOWS_CERT }}
+
+    - name: Prepare certificate 2/2
+      working-directory: .
+      run: 'CMD /r openssl pkcs12 -in cert.pem -export -out cert.pfx -passin pass:"${{ secrets.WINDOWS_CERT_PWD }}" -passout pass:"${{ secrets.WINDOWS_CERT_PWD }}"'
+
+    - name: Sign assembly (ppppp testing)
+      working-directory: .
+      run: 'CMD /r "C:\Program Files (x86)\Windows Kits\10\bin\x86\signtool.exe" sign /f cert.pfx /p ${{ secrets.WINDOWS_CERT_PWD }} bin\Release\Coveo.Connectors.EasyFilePusher.dll'
 
     - name: Compile WinX86
       working-directory: ./src
@@ -35,26 +50,15 @@ jobs:
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=LinuxX64 --configuration Release
 
-    - name: TEST SIGN PPPPP 1
-      id: write_file
-      uses: timheuer/base64-to-file@v1
-      with:
-        fileName: 'cert.pem'
-        encodedString: ${{ secrets.WINDOWS_CERT }}
-
-    - name: TEST SIGN PPPPP 2
-      working-directory: .
-      run: 'CMD /r openssl pkcs12 -in cert.pem -export -out cert.pfx -passin pass:"${{ secrets.WINDOWS_CERT_PWD }}" -passout pass:"${{ secrets.WINDOWS_CERT_PWD }}"'
-
-    - name: TEST SIGN PPPPP 3
+    - name: Sign Windows executable
       working-directory: .
       run: 'CMD /r "C:\Program Files (x86)\Windows Kits\10\bin\x86\signtool.exe" sign /f cert.pfx /p ${{ secrets.WINDOWS_CERT_PWD }} bin\Release\netcoreapp3.1\publish\WinX86\Coveo.Connectors.EasyFilePusher.exe'
 
-    - name: TEST SIGN PPPPP 3
+    - name: Delete temp certificate 1/2
       working-directory: .
       run: 'DEL cert.pfx'
 
-    - name: TEST SIGN PPPPP 4
+    - name: Delete temp certificate 2/2
       working-directory: .
       run: 'DEL cert.pem'
 

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-prerelease:
+  build-and-release:
     runs-on: ubuntu-latest
     steps:
 
@@ -39,13 +39,17 @@ jobs:
         exclusions: '*.pdb'
         type: zip
 
+    - name: Ppppp
+      run: "find -iname '*.zip'"
+
     - name: Create pre-release
       uses: marvinpinto/action-automatic-releases@latest
+      if: ${{false}}
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"
         prerelease: true
-        title: "Test Build"
+        title: "Test Release"
         files: |
-          Coveo.Connectors.EasyFilePusher_WinX86.zip
+          ./bin/Release/netcoreapp3.1/publish/WinX86/Coveo.Connectors.EasyFilePusher_WinX86.zip
           ppppp*.jar

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -30,9 +30,10 @@ jobs:
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=WinX86 --configuration Release
     - name: Zip WinX86 EXE
+      working-directory: ./bin/Release/netcoreapp3.1/publish
       uses: thedoctor0/zip-release@master
       with:
-        filename: './bin/Release/netcoreapp3.1/publish/EasyFilePusher_WinX86.zip'
-        directory: './bin/Release/netcoreapp3.1/publish/WinX86'
+        filename: 'EasyFilePusher_WinX86.zip'
+        directory: './WinX86'
         exclusions: '*.pdb'
         type: zip

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -39,26 +39,20 @@ jobs:
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=LinuxX64 --configuration Release
 
-    - name: TEST SIGN PPPPP 0.1
-      working-directory: .
-      run: 'CMD /r DIR "C:\Program Files\signtool.exe" /s /b'
-
-    - name: TEST SIGN PPPPP 0.2
+    - name: TEST SIGN PPPPP 0
       working-directory: .
       run: 'CMD /r DIR "C:\Program Files (x86)\signtool.exe" /s /b'
 
     - name: TEST SIGN PPPPP 1
       id: write_file
       uses: timheuer/base64-to-file@v1
-      if: ${{false}}
       with:
         fileName: 'win-cert.pfx'
         encodedString: ${{ secrets.WINDOWS_CERT }}
 
     - name: TEST SIGN PPPPP 2
       working-directory: .
-      if: ${{false}}
-      run: 'signtool sign /f win-cert.pfx /p ${{ secrets.WINDOWS_CERT_PWD }} bin\Release\netcoreapp3.1\publish\WinX86\Coveo.Connectors.EasyFilePusher.exe'
+      run: '"C:\Program Files (x86)\Windows Kits\10\bin\x86\signtool.exe" sign /f win-cert.pfx /p ${{ secrets.WINDOWS_CERT_PWD }} bin\Release\netcoreapp3.1\publish\WinX86\Coveo.Connectors.EasyFilePusher.exe'
 
     - name: TEST SIGN PPPPP 3
       working-directory: .

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -39,15 +39,25 @@ jobs:
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=LinuxX64 --configuration Release
 
+    - name: TEST SIGN PPPPP 00001
+      working-directory: .
+      run: 'CMD /r DIR "C:\Program Files\openssl.exe" /s /b'
+
+    - name: TEST SIGN PPPPP 00002
+      working-directory: .
+      run: 'CMD /r DIR "C:\Program Files (x86)\openssl.exe" /s /b'
+
     - name: TEST SIGN PPPPP 1
       id: write_file
       uses: timheuer/base64-to-file@v1
+      if: ${{false}}
       with:
         fileName: 'win-cert.pfx'
         encodedString: ${{ secrets.WINDOWS_CERT }}
 
     - name: TEST SIGN PPPPP 2
       working-directory: .
+      if: ${{false}}
       run: 'CMD /r "C:\Program Files (x86)\Windows Kits\10\bin\x86\signtool.exe" sign /f win-cert.pfx /p ${{ secrets.WINDOWS_CERT_PWD }} bin\Release\netcoreapp3.1\publish\WinX86\Coveo.Connectors.EasyFilePusher.exe'
 
     - name: TEST SIGN PPPPP 3

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -39,16 +39,26 @@ jobs:
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=LinuxX64 --configuration Release
 
+    - name: TEST SIGN PPPPP 0
+      working-directory: .
+      run: 'DIR C:\signtool.exe /s /b'
+
     - name: TEST SIGN PPPPP 1
       id: write_file
       uses: timheuer/base64-to-file@v1
+      if: ${{false}}
       with:
         fileName: 'win-cert.pfx'
         encodedString: ${{ secrets.WINDOWS_CERT }}
 
     - name: TEST SIGN PPPPP 2
       working-directory: .
+      if: ${{false}}
       run: 'signtool sign /f win-cert.pfx /p ${{ secrets.WINDOWS_CERT_PWD }} bin\Release\netcoreapp3.1\publish\WinX86\Coveo.Connectors.EasyFilePusher.exe'
+
+    - name: TEST SIGN PPPPP 3
+      working-directory: .
+      run: 'DEL win-cert.pfx'
 
     - name: Zip WinX86 EXE
       uses: thedoctor0/zip-release@master

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-release:
+  build:
     runs-on: ubuntu-latest
     steps:
 
@@ -31,11 +31,27 @@ jobs:
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=WinX86 --configuration Release
 
+    - name: Publish MacOsx64
+      working-directory: ./src
+      run: dotnet publish -p:PublishProfile=MacOsx64 --configuration Release
+
+    - name: Publish LinuxX64
+      working-directory: ./src
+      run: dotnet publish -p:PublishProfile=LinuxX64 --configuration Release
+
     - name: Zip WinX86 EXE
       uses: thedoctor0/zip-release@master
       with:
         filename: 'Coveo.Connectors.EasyFilePusher_WinX86.zip'
         directory: './bin/Release/netcoreapp3.1/publish/WinX86'
+        exclusions: '*.pdb'
+        type: zip
+
+    - name: Zip MacOsx64 EXE
+      uses: thedoctor0/zip-release@master
+      with:
+        filename: 'Coveo.Connectors.EasyFilePusher_MacOsx64.zip'
+        directory: './bin/Release/netcoreapp3.1/publish/MacOsx64'
         exclusions: '*.pdb'
         type: zip
 
@@ -48,4 +64,4 @@ jobs:
         title: "Test Release"
         files: |
           ./bin/Release/netcoreapp3.1/publish/WinX86/Coveo.Connectors.EasyFilePusher_WinX86.zip
-          ppppp*.jar
+          ./bin/Release/netcoreapp3.1/publish/MacOsx64/Coveo.Connectors.EasyFilePusher_MacOsx64.zip

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-and-release:
-    runs-on: macos-latest
+    runs-on: windows-latest
     steps:
 
     - uses: actions/checkout@v2
@@ -39,8 +39,20 @@ jobs:
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=LinuxX64 --configuration Release
 
+    - name: TEST SIGN PPPPP 1
+        id: write_file
+        uses: timheuer/base64-to-file@v1
+        with:
+          fileName: 'win-cert.pfx'
+          encodedString: ${{ secrets.WINDOWS_CERT }}
+
+    - name: TEST SIGN PPPPP 2
+      working-directory: .
+      run: 'signtool sign /f win-cert.pfx /p ${{ secrets.WINDOWS_CERT_PWD }} bin\Release\netcoreapp3.1\publish\WinX86\Coveo.Connectors.EasyFilePusher.exe'
+
     - name: Zip WinX86 EXE
       uses: thedoctor0/zip-release@master
+      if: ${{false}}
       with:
         filename: 'Coveo.Connectors.EasyFilePusher_WinX86.zip'
         directory: './bin/Release/netcoreapp3.1/publish/WinX86'
@@ -49,6 +61,7 @@ jobs:
 
     - name: Zip MacOsx64 EXE
       uses: thedoctor0/zip-release@master
+      if: ${{false}}
       with:
         filename: 'Coveo.Connectors.EasyFilePusher_MacOsx64.zip'
         directory: './bin/Release/netcoreapp3.1/publish/MacOsx64'
@@ -57,6 +70,7 @@ jobs:
 
     - name: Zip LinuxX64 EXE
       uses: thedoctor0/zip-release@master
+      if: ${{false}}
       with:
         filename: 'Coveo.Connectors.EasyFilePusher_LinuxX64.zip'
         directory: './bin/Release/netcoreapp3.1/publish/LinuxX64'
@@ -75,3 +89,13 @@ jobs:
           ./bin/Release/netcoreapp3.1/publish/WinX86/Coveo.Connectors.EasyFilePusher_WinX86.zip
           ./bin/Release/netcoreapp3.1/publish/MacOsx64/Coveo.Connectors.EasyFilePusher_MacOsx64.zip
           ./bin/Release/netcoreapp3.1/publish/LinuxX64/Coveo.Connectors.EasyFilePusher_LinuxX64.zip
+
+    - name: TEST RELEASE ppppp
+      uses: marvinpinto/action-automatic-releases@latest
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest"
+        prerelease: true
+        title: "Test Release"
+        files: |
+          ./bin/Release/netcoreapp3.1/publish/WinX86/Coveo.Connectors.EasyFilePusher.exe

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: TEST SIGN PPPPP 0
       working-directory: .
-      run: 'DIR C:\signtool.exe /s /b'
+      run: 'CMD /r DIR C:\signtool.exe /s /b'
 
     - name: TEST SIGN PPPPP 1
       id: write_file

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -23,10 +23,6 @@ jobs:
       working-directory: ./src
       run: dotnet build --configuration Release --no-restore
 
-    - name: Test
-      working-directory: ./src
-      run: dotnet test --no-restore --verbosity normal
-
     - name: Compile WinX86
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=WinX86 --configuration Release
@@ -48,7 +44,7 @@ jobs:
 
     - name: TEST SIGN PPPPP 2
       working-directory: .
-      run: 'CMD /r openssl pkcs12 -in cert.pem -export -out cert.pfx -passin pass:"${{ secrets.WINDOWS_CERT_PWD }}" -passout pass:"$${{ secrets.WINDOWS_CERT_PWD }}"'
+      run: 'CMD /r openssl pkcs12 -in cert.pem -export -out cert.pfx -passin pass:"${{ secrets.WINDOWS_CERT_PWD }}" -passout pass:"${{ secrets.WINDOWS_CERT_PWD }}"'
 
     - name: TEST SIGN PPPPP 3
       working-directory: .

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -39,30 +39,28 @@ jobs:
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=LinuxX64 --configuration Release
 
-    - name: TEST SIGN PPPPP 00001
-      working-directory: .
-      run: 'CMD /r DIR "C:\Program Files\openssl.exe" /s /b'
-
-    - name: TEST SIGN PPPPP 00002
-      working-directory: .
-      run: 'CMD /r DIR "C:\Program Files (x86)\openssl.exe" /s /b'
-
     - name: TEST SIGN PPPPP 1
       id: write_file
       uses: timheuer/base64-to-file@v1
-      if: ${{false}}
       with:
-        fileName: 'win-cert.pfx'
+        fileName: 'cert.pem'
         encodedString: ${{ secrets.WINDOWS_CERT }}
 
     - name: TEST SIGN PPPPP 2
       working-directory: .
-      if: ${{false}}
-      run: 'CMD /r "C:\Program Files (x86)\Windows Kits\10\bin\x86\signtool.exe" sign /f win-cert.pfx /p ${{ secrets.WINDOWS_CERT_PWD }} bin\Release\netcoreapp3.1\publish\WinX86\Coveo.Connectors.EasyFilePusher.exe'
+      run: 'CMD /r openssl pkcs12 -in cert.pem -export -out cert.pfx -passin pass:"${{ secrets.WINDOWS_CERT_PWD }}" -passout pass:"$${{ secrets.WINDOWS_CERT_PWD }}"'
 
     - name: TEST SIGN PPPPP 3
       working-directory: .
-      run: 'DEL win-cert.pfx'
+      run: 'CMD /r "C:\Program Files (x86)\Windows Kits\10\bin\x86\signtool.exe" sign /f cert.pfx /p ${{ secrets.WINDOWS_CERT_PWD }} bin\Release\netcoreapp3.1\publish\WinX86\Coveo.Connectors.EasyFilePusher.exe'
+
+    - name: TEST SIGN PPPPP 3
+      working-directory: .
+      run: 'DEL cert.pfx'
+
+    - name: TEST SIGN PPPPP 4
+      working-directory: .
+      run: 'DEL cert.pem'
 
     - name: Zip WinX86 EXE
       uses: thedoctor0/zip-release@master

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -29,3 +29,11 @@ jobs:
     - name: Publish WinX86
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=WinX86 --configuration Release
+    - name: Zip WinX86 EXE
+      uses: thedoctor0/zip-release@master
+      with:
+        filename: 'EasyFilePusher_WinX86.zip'
+        path: './bin/Release/netcoreapp3.1/publish'
+        directory: './bin/Release/netcoreapp3.1/publish/WinX86'
+        exclusions: '*.pdb'
+        type: zip

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -7,32 +7,49 @@ on:
         description: 'Input test'  
 
 jobs:
-  build:
-
+  build-and-prerelease:
     runs-on: ubuntu-latest
-
     steps:
+
     - uses: actions/checkout@v2
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.101
+
     - name: Install dependencies
       working-directory: ./src
       run: dotnet restore
+
     - name: Build
       working-directory: ./src
       run: dotnet build --configuration Release --no-restore
+
     - name: Test
       working-directory: ./src
       run: dotnet test --no-restore --verbosity normal
+
     - name: Publish WinX86
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=WinX86 --configuration Release
+
     - name: Zip WinX86 EXE
       uses: thedoctor0/zip-release@master
       with:
-        filename: 'EasyFilePusher_WinX86.zip'
+        filename: 'Coveo.Connectors.EasyFilePusher_WinX86.zip'
         directory: './bin/Release/netcoreapp3.1/publish/WinX86'
         exclusions: '*.pdb'
         type: zip
+          echo "done!"
+
+    - name: Create pre-release
+      uses: marvinpinto/action-automatic-releases@latest
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest"
+        prerelease: true
+        title: "Test Build"
+        files: |
+          Coveo.Connectors.EasyFilePusher_WinX86.zip
+          ppppp*.jar

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -1,0 +1,31 @@
+name: Publish Test
+
+on: 
+  workflow_dispatch:
+    inputs:
+      test:
+        description: 'Input test'  
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+    - name: Install dependencies
+      working-directory: ./src
+      run: dotnet restore
+    - name: Build
+      working-directory: ./src
+      run: dotnet build --configuration Release --no-restore
+    - name: Test
+      working-directory: ./src
+      run: dotnet test --no-restore --verbosity normal
+    - name: Publish WinX86
+      working-directory: ./src
+      run: dotnet publish -p:PublishProfile=WinX86 --configuration Release

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -33,7 +33,6 @@ jobs:
       uses: thedoctor0/zip-release@master
       with:
         filename: 'EasyFilePusher_WinX86.zip'
-        path: './bin/Release/netcoreapp3.1/publish'
         directory: './bin/Release/netcoreapp3.1/publish/WinX86'
         exclusions: '*.pdb'
         type: zip

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -30,10 +30,9 @@ jobs:
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=WinX86 --configuration Release
     - name: Zip WinX86 EXE
-      working-directory: ./bin/Release/netcoreapp3.1/publish
       uses: thedoctor0/zip-release@master
       with:
         filename: 'EasyFilePusher_WinX86.zip'
-        directory: './WinX86'
+        directory: './bin/Release/netcoreapp3.1/publish/WinX86'
         exclusions: '*.pdb'
         type: zip

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -1,7 +1,10 @@
 name: Publish Test
 
 on: 
-  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build-and-release:

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build-and-release:
     runs-on: ubuntu-latest
     steps:
 
@@ -55,6 +55,14 @@ jobs:
         exclusions: '*.pdb'
         type: zip
 
+    - name: Zip LinuxX64 EXE
+      uses: thedoctor0/zip-release@master
+      with:
+        filename: 'Coveo.Connectors.EasyFilePusher_LinuxX64.zip'
+        directory: './bin/Release/netcoreapp3.1/publish/LinuxX64'
+        exclusions: '*.pdb'
+        type: zip
+
     - name: Create pre-release
       uses: marvinpinto/action-automatic-releases@latest
       with:
@@ -65,3 +73,4 @@ jobs:
         files: |
           ./bin/Release/netcoreapp3.1/publish/WinX86/Coveo.Connectors.EasyFilePusher_WinX86.zip
           ./bin/Release/netcoreapp3.1/publish/MacOsx64/Coveo.Connectors.EasyFilePusher_MacOsx64.zip
+          ./bin/Release/netcoreapp3.1/publish/LinuxX64/Coveo.Connectors.EasyFilePusher_LinuxX64.zip

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -23,21 +23,6 @@ jobs:
       working-directory: ./src
       run: dotnet build --configuration Release --no-restore
       
-    - name: Prepare certificate 1/2
-      id: write_file
-      uses: timheuer/base64-to-file@v1
-      with:
-        fileName: 'cert.pem'
-        encodedString: ${{ secrets.WINDOWS_CERT }}
-
-    - name: Prepare certificate 2/2
-      working-directory: .
-      run: 'CMD /r openssl pkcs12 -in cert.pem -export -out cert.pfx -passin pass:"${{ secrets.WINDOWS_CERT_PWD }}" -passout pass:"${{ secrets.WINDOWS_CERT_PWD }}"'
-
-    - name: Sign assembly (ppppp testing)
-      working-directory: .
-      run: 'CMD /r "C:\Program Files (x86)\Windows Kits\10\bin\x86\signtool.exe" sign /f cert.pfx /p ${{ secrets.WINDOWS_CERT_PWD }} bin\Release\Coveo.Connectors.EasyFilePusher.dll'
-
     - name: Compile WinX86
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=WinX86 --configuration Release
@@ -49,6 +34,17 @@ jobs:
     - name: Compile LinuxX64
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=LinuxX64 --configuration Release
+
+    - name: Prepare certificate 1/2
+      id: write_file
+      uses: timheuer/base64-to-file@v1
+      with:
+        fileName: 'cert.pem'
+        encodedString: ${{ secrets.WINDOWS_CERT }}
+
+    - name: Prepare certificate 2/2
+      working-directory: .
+      run: 'CMD /r openssl pkcs12 -in cert.pem -export -out cert.pfx -passin pass:"${{ secrets.WINDOWS_CERT_PWD }}" -passout pass:"${{ secrets.WINDOWS_CERT_PWD }}"'
 
     - name: Sign Windows executable
       working-directory: .
@@ -63,35 +59,19 @@ jobs:
       run: 'DEL cert.pem'
 
     - name: Zip WinX86 EXE
-      uses: thedoctor0/zip-release@master
-      if: ${{false}}
-      with:
-        filename: 'Coveo.Connectors.EasyFilePusher_WinX86.zip'
-        directory: './bin/Release/netcoreapp3.1/publish/WinX86'
-        exclusions: '*.pdb'
-        type: zip
+      working-directory: .
+      run: 'Compress-Archive bin\Release\netcoreapp3.1\publish\WinX86\Coveo.Connectors.EasyFilePusher.exe bin\Release\netcoreapp3.1\publish\WinX86\Coveo.Connectors.EasyFilePusher_WinX86.zip'
 
     - name: Zip MacOsx64 EXE
-      uses: thedoctor0/zip-release@master
-      if: ${{false}}
-      with:
-        filename: 'Coveo.Connectors.EasyFilePusher_MacOsx64.zip'
-        directory: './bin/Release/netcoreapp3.1/publish/MacOsx64'
-        exclusions: '*.pdb'
-        type: zip
+      working-directory: .
+      run: 'Compress-Archive bin\Release\netcoreapp3.1\publish\MacOsx64\Coveo.Connectors.EasyFilePusher bin\Release\netcoreapp3.1\publish\MacOsx64\Coveo.Connectors.EasyFilePusher_MacOsx64.zip'
 
     - name: Zip LinuxX64 EXE
-      uses: thedoctor0/zip-release@master
-      if: ${{false}}
-      with:
-        filename: 'Coveo.Connectors.EasyFilePusher_LinuxX64.zip'
-        directory: './bin/Release/netcoreapp3.1/publish/LinuxX64'
-        exclusions: '*.pdb'
-        type: zip
+      working-directory: .
+      run: 'Compress-Archive bin\Release\netcoreapp3.1\publish\LinuxX64\Coveo.Connectors.EasyFilePusher bin\Release\netcoreapp3.1\publish\LinuxX64\Coveo.Connectors.EasyFilePusher_LinuxX64.zip'
 
     - name: Release executables
       uses: marvinpinto/action-automatic-releases@latest
-      if: ${{false}}
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"
@@ -101,13 +81,3 @@ jobs:
           ./bin/Release/netcoreapp3.1/publish/WinX86/Coveo.Connectors.EasyFilePusher_WinX86.zip
           ./bin/Release/netcoreapp3.1/publish/MacOsx64/Coveo.Connectors.EasyFilePusher_MacOsx64.zip
           ./bin/Release/netcoreapp3.1/publish/LinuxX64/Coveo.Connectors.EasyFilePusher_LinuxX64.zip
-
-    - name: TEST RELEASE ppppp
-      uses: marvinpinto/action-automatic-releases@latest
-      with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "latest"
-        prerelease: true
-        title: "Test Release"
-        files: |
-          ./bin/Release/netcoreapp3.1/publish/WinX86/Coveo.Connectors.EasyFilePusher.exe

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -39,9 +39,13 @@ jobs:
       working-directory: ./src
       run: dotnet publish -p:PublishProfile=LinuxX64 --configuration Release
 
-    - name: TEST SIGN PPPPP 0
+    - name: TEST SIGN PPPPP 0.1
       working-directory: .
-      run: 'CMD /r DIR C:\signtool.exe /s /b'
+      run: 'CMD /r DIR "C:\Program Files\signtool.exe" /s /b'
+
+    - name: TEST SIGN PPPPP 0.2
+      working-directory: .
+      run: 'CMD /r DIR "C:\Program Files (x86)\signtool.exe" /s /b'
 
     - name: TEST SIGN PPPPP 1
       id: write_file

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-and-release:
-    runs-on: windows-latest
+    runs-on: macos-latest
     steps:
 
     - uses: actions/checkout@v2
@@ -65,6 +65,7 @@ jobs:
 
     - name: Release executables
       uses: marvinpinto/action-automatic-releases@latest
+      if: ${{false}}
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"

--- a/.github/workflows/dotnet-publish-test.yml
+++ b/.github/workflows/dotnet-publish-test.yml
@@ -40,11 +40,11 @@ jobs:
       run: dotnet publish -p:PublishProfile=LinuxX64 --configuration Release
 
     - name: TEST SIGN PPPPP 1
-        id: write_file
-        uses: timheuer/base64-to-file@v1
-        with:
-          fileName: 'win-cert.pfx'
-          encodedString: ${{ secrets.WINDOWS_CERT }}
+      id: write_file
+      uses: timheuer/base64-to-file@v1
+      with:
+        fileName: 'win-cert.pfx'
+        encodedString: ${{ secrets.WINDOWS_CERT }}
 
     - name: TEST SIGN PPPPP 2
       working-directory: .

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -1,4 +1,4 @@
-name: Publish Test
+name: Publish the Easy File Pusher tool.
 
 on: 
   push:
@@ -79,7 +79,7 @@ jobs:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"
         prerelease: true
-        title: "Test Release"
+        title: "Latest Release"
         files: |
           ./bin/Release/netcoreapp3.1/publish/WinX86/Coveo.Connectors.EasyFilePusher_WinX86.zip
           ./bin/Release/netcoreapp3.1/publish/MacOsx64/Coveo.Connectors.EasyFilePusher_MacOsx64.zip

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -18,13 +18,9 @@ jobs:
       with:
         dotnet-version: 3.1.101
 
-    - name: Install dependencies
-      working-directory: ./src
-      run: dotnet restore
-
     - name: Build
       working-directory: ./src
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release
       
     - name: Compile WinX86
       working-directory: ./src
@@ -78,7 +74,7 @@ jobs:
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"
-        prerelease: true
+        prerelease: false
         title: "Latest Release"
         files: |
           ./bin/Release/netcoreapp3.1/publish/WinX86/Coveo.Connectors.EasyFilePusher_WinX86.zip

--- a/src/Coveo.Connectors.EasyFilePusher/Properties/PublishProfiles/LinuxX64.pubxml
+++ b/src/Coveo.Connectors.EasyFilePusher/Properties/PublishProfiles/LinuxX64.pubxml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>..\..\bin\Release\netcoreapp3.1\publish\LinuxX64</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>True</PublishSingleFile>
+    <PublishTrimmed>True</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/src/Coveo.Connectors.EasyFilePusher/Properties/PublishProfiles/MacOsx64.pubxml
+++ b/src/Coveo.Connectors.EasyFilePusher/Properties/PublishProfiles/MacOsx64.pubxml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>..\..\bin\Release\netcoreapp3.1\publish\MacOsx64</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>True</PublishSingleFile>
+    <PublishTrimmed>True</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/src/Coveo.Connectors.EasyFilePusher/Properties/PublishProfiles/WinX86.pubxml
+++ b/src/Coveo.Connectors.EasyFilePusher/Properties/PublishProfiles/WinX86.pubxml
@@ -12,7 +12,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
+    <PublishReadyToRun>False</PublishReadyToRun>
     <PublishTrimmed>True</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/src/Coveo.Connectors.EasyFilePusher/Properties/PublishProfiles/WinX86.pubxml
+++ b/src/Coveo.Connectors.EasyFilePusher/Properties/PublishProfiles/WinX86.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>..\..\bin\Release\netcoreapp3.1\publish\WinX86</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>True</PublishSingleFile>
+    <PublishReadyToRun>True</PublishReadyToRun>
+    <PublishTrimmed>True</PublishTrimmed>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
La première pull request était pour le code source comme tel du Easy File Pusher.  Celle-ci est pour la processus de build.  Je ne sais pas jusqu'à quel point vous êtes à l'aise avec la syntaxe YML, mais c'est surtout dans le fichier _dotnet-publish.yml_ que ça se passe.  C'était un peu étrange la façon de tester.  Je devais commiter le changement à tester dans la branche.  Ensuite, j'avais un bouton qui apparaissait (avant de changer le "on:") dans le UI de GitHub qui me permettait de tester mon changement.  Ça m'a forcé à faire plein de commits d'exploration.  En tout cas, au final, ça marche.  :-)

Dans la version actuelle, ça ne garde qu'une seule release dans GitHub.  Celle qui existe présentement s'appelle "Test Release": 
 https://github.com/coveooss/easy-file-pusher/releases .  Expander "Assets" pour voir les 3 fichiers zip.

Dans ce que je vous demande de réviser ici, j'ai renommé "Test Release" pour "Latest Release".  Et elle est flaggée "prerelease". 
 Ça prend une invention manuelle de quelqu'un pour enlever le flag "prerelease".  Mais ça peut se changer facilement dans le script.  Ça serait à discuter aussi de si on veut garder les releases précédentes et en créer une nouvelle à chaque fois et garder les anciennes.  Présentement, les zips dans la release se font simplement écraser par les nouveaux.

p.s.  Pour la question de l'exécutable Mac, si on vient qu'à le signer comme on serait supposé de le faire, ça sera dans un Story séparé.  Faut d'abord ouvrir une PM Request pour voir jusqu'à quel point Coveo veut rendre le tool disponible sur cette plateforme.  Et si on vient qu'à le faire, ça nous prendra un compte de développeur chez Apple, un peu le même principe que MSDN avec Microsoft, j'imagine...